### PR TITLE
fix: improve YouTube digest shorts tracking

### DIFF
--- a/.github/workflows/youtube-digest.yml
+++ b/.github/workflows/youtube-digest.yml
@@ -1,13 +1,20 @@
 name: 📺 YouTube 유튜브 다이제스트 (매일 09:00 KST)
 
-# Daily YouTube subtitle digest for ~22 Korean stock-market channels.
-# Offloads heavy yt-dlp from the local WkAutoQuant briefing bot (was freezing the host).
-# Outputs: wavevault/youtube_digest/<YYYY-MM-DD>_<slug>.txt + youtube_digest.json
+# Daily YouTube subtitle digest for Korean stock-market channels.
+# Offloads heavy yt-dlp from the local WkAutoQuant briefing bot.
+# Outputs: youtube_digest.json + wavevault/youtube_digest/<YYYY-MM-DD>_<slug>.txt
 
 on:
   schedule:
     # 09:00 KST = 00:00 UTC, daily
     - cron: "0 0 * * *"
+    # 18:00 KST = 09:00 UTC, catches afternoon and shorts updates
+    - cron: "0 9 * * *"
+  push:
+    paths:
+      - ".github/workflows/youtube-digest.yml"
+      - "scripts/youtube_digest.py"
+      - "scripts/youtube_digest_plus.py"
   workflow_dispatch:
     inputs:
       channel:
@@ -29,7 +36,7 @@ concurrency:
 jobs:
   fetch:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
 
     steps:
       - name: Checkout
@@ -40,12 +47,19 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Setup Node runtime for yt-dlp player JS
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Install yt-dlp
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade yt-dlp
+          node --version
+          python -m yt_dlp --version
 
-      - name: Write YouTube cookies (bypass bot detection on data-center IPs)
+      - name: Write YouTube cookies
         env:
           YOUTUBE_COOKIES: ${{ secrets.YOUTUBE_COOKIES }}
         run: |
@@ -53,7 +67,7 @@ jobs:
             printf '%s\n' "$YOUTUBE_COOKIES" > cookies.txt
             echo "[cookies] wrote $(wc -l < cookies.txt) lines to cookies.txt"
           else
-            echo "[cookies] YOUTUBE_COOKIES secret is empty; skipping (yt-dlp will run without cookies)"
+            echo "[cookies] YOUTUBE_COOKIES secret is empty; yt-dlp will try alternate clients"
           fi
 
       - name: Run YouTube digest
@@ -67,9 +81,19 @@ jobs:
           if [ -n "${{ github.event.inputs.timeout }}" ]; then
             ARGS="$ARGS --timeout ${{ github.event.inputs.timeout }}"
           fi
-          python scripts/youtube_digest.py $ARGS
+          python scripts/youtube_digest_plus.py $ARGS
+          python - <<'PY'
+          import json, pathlib
+          p = pathlib.Path('youtube_digest.json')
+          if not p.exists():
+              raise SystemExit('youtube_digest.json was not created')
+          d = json.loads(p.read_text(encoding='utf-8'))
+          print('[digest-summary]', d.get('success_count'), '/', d.get('channel_count'), 'ok')
+          print('[digest-shorts]', d.get('shorts_success_count'), '/', d.get('shorts_channel_count'), 'ok')
+          print('[digest-stockcrazypeople]', d.get('stockcrazypeople'))
+          PY
 
-      - name: Cleanup cookies (defense-in-depth; .gitignore already blocks it)
+      - name: Cleanup cookies
         if: always()
         run: rm -f cookies.txt
 
@@ -83,7 +107,6 @@ jobs:
             exit 0
           fi
           git commit -m "chore(youtube-digest): refresh transcripts $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          # Pull-rebase to avoid clobbering parallel commits from sibling workflows.
           git pull --rebase origin main || true
           git push origin HEAD:main
 
@@ -95,16 +118,19 @@ jobs:
           if [ -z "$GH_PAT" ]; then
             echo "[cross-push] GH_PAT secret missing, skipping"; exit 0
           fi
-          if [ ! -d wavevault/youtube_digest ]; then
-            echo "[cross-push] no digest dir, skipping"; exit 0
+          if [ ! -f youtube_digest.json ]; then
+            echo "[cross-push] no manifest, skipping"; exit 0
           fi
           git clone --depth=1 "https://x-access-token:${GH_PAT}@github.com/kiexpert/WkAutoQuant.git" /tmp/wkaq
           mkdir -p /tmp/wkaq/wavevault/youtube_digest
-          cp -r wavevault/youtube_digest/. /tmp/wkaq/wavevault/youtube_digest/
+          if [ -d wavevault/youtube_digest ]; then
+            cp -r wavevault/youtube_digest/. /tmp/wkaq/wavevault/youtube_digest/
+          fi
+          cp youtube_digest.json /tmp/wkaq/wavevault/youtube_digest.json
           cd /tmp/wkaq
           git config user.name  "WkFeedQuant Bot"
           git config user.email "action@github.com"
-          git add wavevault/youtube_digest/ || true
+          git add wavevault/youtube_digest.json wavevault/youtube_digest/ || true
           if git diff --cached --quiet; then
             echo "[cross-push] no changes for WkAutoQuant"; exit 0
           fi

--- a/scripts/youtube_digest_plus.py
+++ b/scripts/youtube_digest_plus.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Extended YouTube digest entrypoint.
+
+Adds compatibility aliases and metrics without rewriting the base fetcher.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import sys
+
+import youtube_digest as yd
+
+
+EXTRA_CHANNELS = [
+    {
+        "slug": "stockcrazypeople",
+        "url": "https://www.youtube.com/@stockcrazypeople/videos",
+        "min_duration": 300,
+        "label": "주식에 미친 사람들",
+    },
+    {
+        "slug": "stockcrazypeople_shorts",
+        "url": "https://www.youtube.com/@stockcrazypeople/shorts",
+        "min_duration": 0,
+        "label": "주식에 미친 사람들 쇼츠",
+    },
+]
+
+
+def _dedupe_channels(channels: list[dict]) -> list[dict]:
+    seen: set[tuple[str, str]] = set()
+    out: list[dict] = []
+    for ch in channels:
+        key = (str(ch.get("slug", "")), str(ch.get("url", "")))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ch)
+    return out
+
+
+# Existing *_shorts entries remain active. This adds explicit tracking for
+# 주식에 미친 사람들 while preserving the older jusikmijin channel entry.
+yd.CHANNELS = _dedupe_channels(list(yd.CHANNELS) + EXTRA_CHANNELS)
+
+
+def write_index_with_shorts(results: list[dict], started_iso: str) -> None:
+    finished_iso = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    successes = [r for r in results if r.get("ok")]
+    failures = [r for r in results if not r.get("ok")]
+    shorts = [r for r in results if str(r.get("slug", "")).endswith("_shorts")]
+    shorts_ok = [r for r in shorts if r.get("ok")]
+    stockcrazy = [r for r in results if str(r.get("slug", "")).startswith("stockcrazypeople")]
+    index = {
+        "schema_version": 2,
+        "generated_at": finished_iso,
+        "started_at": started_iso,
+        "channel_count": len(results),
+        "success_count": len(successes),
+        "failure_count": len(failures),
+        "shorts_channel_count": len(shorts),
+        "shorts_success_count": len(shorts_ok),
+        "stockcrazypeople": stockcrazy,
+        "channels": results,
+    }
+    yd.INDEX_PATH.write_text(json.dumps(index, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(
+        f"[INDEX] {yd.INDEX_PATH.name} written: "
+        f"{len(successes)}/{len(results)} ok; shorts={len(shorts_ok)}/{len(shorts)} ok",
+        flush=True,
+    )
+
+
+yd.write_index = write_index_with_shorts
+
+
+if __name__ == "__main__":
+    sys.exit(yd.main())


### PR DESCRIPTION
## Summary

Make WkFeedQuant YouTube digest more reliable and make shorts tracking explicit for all registered `*_shorts` channels.

## Changes

- Add `scripts/youtube_digest_plus.py`
  - Wraps the existing `youtube_digest.py` without rewriting the base fetcher
  - Keeps all existing registered channels and existing `*_shorts` entries active
  - Adds explicit `stockcrazypeople` / `stockcrazypeople_shorts` aliases for 주식에 미친 사람들
  - Writes schema v2 manifest with:
    - `shorts_channel_count`
    - `shorts_success_count`
    - `stockcrazypeople`

- Update `.github/workflows/youtube-digest.yml`
  - Runs `youtube_digest_plus.py`
  - Adds 18:00 KST schedule for afternoon/shorts updates
  - Adds push trigger for workflow/script changes
  - Installs Node 20 for yt-dlp player JS compatibility
  - Cross-pushes both transcript files and manifest to WkAutoQuant

## Safety

- No trading code changed
- No secrets changed
- Existing channel list remains intact
- Partial YouTube failures still produce manifest/artifact